### PR TITLE
Add decision-based unescaping method

### DIFF
--- a/Classes/GTMNSString+HTML.h
+++ b/Classes/GTMNSString+HTML.h
@@ -63,4 +63,10 @@
 //
 - (NSString *)gtm_stringByUnescapingFromHTML;
 
+/// Similar to gtm_stringByUnescapingFromHTML, but repeatedly invokes a decision block
+/// that accepts a range to replace from and a string to replace to
+/// and returns whether to replace or skip the current range
+//
+- (NSString *)gtm_stringByUnescapingFromHTMLWithDecisionBlock:(BOOL (^)(NSRange rangeToReplaceFrom, NSString *stringToReplaceTo))decisionBlock;
+
 @end


### PR DESCRIPTION
Client (user of this method) can implement a decision block of the following type:
`(BOOL (^)(NSRange rangeToReplaceFrom, NSString *stringToReplaceTo))`
and choose to skip unescaping certain string sequences based on needs.
